### PR TITLE
fix regression - loading config

### DIFF
--- a/react/public/index.html
+++ b/react/public/index.html
@@ -11,6 +11,6 @@
       You need to enable JavaScript to run this app.
     </noscript>
     <div id="root" class="wrap container"></div>
-    <script type="text/javascript" src="/static/build/index.js"></script>
+    <script type="text/javascript" src="/static/build/index-bundle.dev.js"></script>
   </body>
 </html>

--- a/react/public/index.html
+++ b/react/public/index.html
@@ -11,6 +11,6 @@
       You need to enable JavaScript to run this app.
     </noscript>
     <div id="root" class="wrap container"></div>
-    <script type="text/javascript" src="/static/build/index-bundle.dev.js"></script>
+    <script type="text/javascript" src="/static/build/index.js"></script>
   </body>
 </html>

--- a/react/src/actions/Config.js
+++ b/react/src/actions/Config.js
@@ -7,6 +7,7 @@ export const GET_JSCONFIG_CONFIG_FAIL = 'GET_JSCONFIG_CONFIG_FAIL';
 export const NEW_CSRF_TOKEN = 'NEW_CSRF_TOKEN';
 export const GET_INITIAL_USERDATA = 'GET_INITIAL_USERDATA';
 export const RESIZE_WINDOW = 'RESIZE_WINDOW';
+export const CONFIG_SPA = 'CONFIG_SINGLE_PAGE_APP';
 
 export function getConfig () {
   return {
@@ -39,6 +40,13 @@ export function getInitialUserdata () {
   return {
     type: GET_INITIAL_USERDATA
   };
+}
+
+
+export function configSpa () {
+    return {
+        type: CONFIG_SPA
+    };
 }
 
 

--- a/react/src/init-app.js
+++ b/react/src/init-app.js
@@ -14,8 +14,8 @@ import ReactDOM from 'react-dom';
 
 import { routerMiddleware } from 'react-router-redux';
 
-import { BrowserRouter, Route, Link } from 'react-router-dom';
-import createSagaMiddleware, { takeLatest, takeEvery } from 'redux-saga';
+import createSagaMiddleware from 'redux-saga';
+import rootSaga from './root-saga';
 import { createLogger } from 'redux-logger';
 import { Provider } from 'react-intl-redux'
 import { updateIntl } from 'react-intl-redux';
@@ -23,82 +23,11 @@ import { createStore, applyMiddleware, compose } from "redux";
 import eduIDApp from "./store";
 import notifyAndDispatch from "./notify-middleware";
 import * as configActions from "actions/Config";
-import * as pdataActions from "actions/PersonalData";
-import * as emailActions from "actions/Emails";
-import * as mobileActions from "actions/Mobile"
-import * as openidActions from "actions/OpenidConnect";
-import * as securityActions from "actions/Security";
-import * as pwActions from "actions/ChangePassword";
-import * as ninActions from "actions/Nins";
-import * as openidFrejaActions from "actions/OpenidConnectFreja";
-import * as letterActions from "actions/LetterProofing";
-import * as headerActions from "actions/Header";
 
-import { requestAllPersonalData, savePersonalData } from "sagas/PersonalData";
-import { saveEmail, requestResendEmailCode,
-         requestVerifyEmail, requestRemoveEmail,
-         requestMakePrimaryEmail } from "sagas/Emails";
-import * as sagasMobile from "sagas/Mobile";
-import * as sagasOpenidFreja from "sagas/OpenidConnectFreja";
-import { requestConfig } from "sagas/Config";
-import { requestOpenidQRcode } from "sagas/OpenidConnect";
-import { requestCredentials, requestPasswordChange, postDeleteAccount } from "sagas/Security";
-import { requestSuggestedPassword, postPasswordChange } from "sagas/ChangePassword";
-import { requestNins, requestRemoveNin } from "sagas/Nins";
-import { requestOpenidFrejaData } from "sagas/OpenidConnectFreja";
-import { sendLetterProofing, sendLetterCode } from "sagas/LetterProofing";
-import { requestLogout } from "sagas/Header";
-
-import PersonalDataContainer from 'containers/PersonalData';
-import NinsContainer from 'containers/Nins';
-import EmailsContainer from 'containers/Emails';
-import MobileContainer from 'containers/Mobile';
-import SecurityContainer from 'containers/Security';
-import ChangePasswordContainer from 'containers/ChangePassword';
 import { history } from "components/Main";
 
 
-/* Sagas */
-
-function* rootSaga() {
-  yield [
-    takeLatest(configActions.GET_JSCONFIG_CONFIG, requestConfig),
-    takeLatest(configActions.GET_INITIAL_USERDATA, requestAllPersonalData),
-    takeLatest(configActions.GET_INITIAL_USERDATA, requestCredentials),
-    takeLatest(configActions.GET_INITIAL_USERDATA, requestSuggestedPassword),
-    takeLatest(pdataActions.POST_USERDATA, savePersonalData),
-    takeLatest(openidActions.POST_OIDC_PROOFING_PROOFING, requestOpenidQRcode),
-    takeLatest(openidFrejaActions.POST_OIDC_PROOFING_FREJA_PROOFING, sagasOpenidFreja.initializeOpenidFrejaData),
-    takeLatest(openidFrejaActions.GET_OIDC_PROOFING_FREJA_PROOFING, sagasOpenidFreja.requestOpenidFrejaData),
-    takeLatest(openidFrejaActions.SHOW_OIDC_FREJA_MODAL, sagasOpenidFreja.checkNINAndShowFrejaModal),
-    takeLatest(openidFrejaActions.HIDE_OIDC_FREJA_MODAL, sagasOpenidFreja.closeFrejaModal),
-    takeLatest(emailActions.POST_EMAIL, saveEmail),
-    takeLatest(emailActions.START_RESEND_EMAIL_CODE, requestResendEmailCode),
-    takeLatest(emailActions.START_VERIFY, requestVerifyEmail),
-    takeLatest(emailActions.POST_EMAIL_REMOVE, requestRemoveEmail),
-    takeLatest(emailActions.POST_EMAIL_PRIMARY, requestMakePrimaryEmail),
-    takeLatest(mobileActions.POST_MOBILE, sagasMobile.saveMobile),
-    takeLatest(mobileActions.POST_MOBILE_REMOVE, sagasMobile.requestRemoveMobile),
-    takeLatest(mobileActions.POST_MOBILE_PRIMARY, sagasMobile.requestMakePrimaryMobile),
-    takeLatest(mobileActions.START_RESEND_MOBILE_CODE, sagasMobile.requestResendMobileCode),
-    takeLatest(mobileActions.START_VERIFY, sagasMobile.requestVerifyMobile),
-    takeLatest(securityActions.GET_CHANGE_PASSWORD, requestPasswordChange),
-    takeLatest(pwActions.POST_PASSWORD_CHANGE, postPasswordChange),
-    takeLatest(securityActions.POST_DELETE_ACCOUNT, postDeleteAccount),
-    takeLatest(letterActions.POST_LETTER_PROOFING_CODE, sendLetterProofing),
-    takeLatest(letterActions.POST_LETTER_PROOFING_PROOFING, sendLetterCode),
-    takeLatest(ninActions.POST_NIN_REMOVE, requestRemoveNin),
-    takeEvery(letterActions.STOP_LETTER_PROOFING, requestNins),
-    takeEvery(ninActions.POST_NIN_REMOVE_SUCCESS, requestNins),
-    takeEvery(letterActions.POST_LETTER_PROOFING_CODE_SUCCESS, requestNins),
-    takeEvery(headerActions.POST_LOGOUT, requestLogout),
-  ];
-}
-
-const sagaMiddleware = createSagaMiddleware();
-
 /* for redux dev tools */
-
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 /* to load persisted state from local storage */
@@ -133,6 +62,7 @@ const saveState = (state) => {
 
 /* Store */
 
+const sagaMiddleware = createSagaMiddleware();
 
 export const store = createStore(
     eduIDApp,
@@ -159,9 +89,9 @@ const getConfig = function () {
     store.dispatch(configActions.getConfig());
 };
 
-const getConfigAndData = function () {
+const getConfigSpa = function () {
     store.dispatch(configActions.getConfig());
-    store.dispatch(configActions.getInitialUserdata());
+    store.dispatch(configActions.configSpa());
 };
 
 /* render app */
@@ -187,7 +117,7 @@ const init_app = function (target, component, intl=false) {
             const next = window.location.href;
             window.location.href = TOKEN_SERVICE_URL + '?next=' + next;
         }
-        action = getConfigAndData;
+        action = getConfigSpa;
         const language = navigator.languages
                          ? navigator.languages[0]
                          : (navigator.language || navigator.userLanguage);

--- a/react/src/reducers/Config.js
+++ b/react/src/reducers/Config.js
@@ -7,7 +7,8 @@ const configData = {
     show_sidebar: true,
     is_configured: false,
     is_fetching: false,
-    failed: false
+    failed: false,
+    is_spa: false
 };
 
 const urls_with_no_sidebar = [
@@ -53,6 +54,11 @@ let configReducer = (state=configData, action) => {
       return {
           ...state,
           ...action.payload
+      };
+    case actions.CONFIG_SPA:
+      return {
+          ...state,
+          is_spa: true
       };
     case "@@router/LOCATION_CHANGE":
       let show_sidebar = true;

--- a/react/src/root-saga.js
+++ b/react/src/root-saga.js
@@ -1,0 +1,76 @@
+
+import { takeLatest, takeEvery } from 'redux-saga';
+import { put, select } from "redux-saga/effects";
+import * as configActions from "actions/Config";
+import * as pdataActions from "actions/PersonalData";
+import * as emailActions from "actions/Emails";
+import * as mobileActions from "actions/Mobile"
+import * as openidActions from "actions/OpenidConnect";
+import * as securityActions from "actions/Security";
+import * as pwActions from "actions/ChangePassword";
+import * as ninActions from "actions/Nins";
+import * as openidFrejaActions from "actions/OpenidConnectFreja";
+import * as letterActions from "actions/LetterProofing";
+import * as headerActions from "actions/Header";
+
+import { requestAllPersonalData, savePersonalData } from "sagas/PersonalData";
+import { saveEmail, requestResendEmailCode,
+         requestVerifyEmail, requestRemoveEmail,
+         requestMakePrimaryEmail } from "sagas/Emails";
+import * as sagasMobile from "sagas/Mobile";
+import * as sagasOpenidFreja from "sagas/OpenidConnectFreja";
+import { requestConfig } from "sagas/Config";
+import { requestOpenidQRcode } from "sagas/OpenidConnect";
+import { requestCredentials, requestPasswordChange, postDeleteAccount } from "sagas/Security";
+import { requestSuggestedPassword, postPasswordChange } from "sagas/ChangePassword";
+import { requestNins, requestRemoveNin } from "sagas/Nins";
+import { requestOpenidFrejaData } from "sagas/OpenidConnectFreja";
+import { sendLetterProofing, sendLetterCode } from "sagas/LetterProofing";
+import { requestLogout } from "sagas/Header";
+
+
+function* configSpaSaga () {
+    const state = yield select(state => state);
+    if (state.config.is_spa) {
+        yield put(configActions.getInitialUserdata());
+    }
+}
+
+
+function* rootSaga() {
+  yield [
+    takeLatest(configActions.GET_JSCONFIG_CONFIG, requestConfig),
+    takeLatest(configActions.GET_JSCONFIG_CONFIG_SUCCESS, configSpaSaga),
+    takeLatest(configActions.GET_INITIAL_USERDATA, requestAllPersonalData),
+    takeLatest(configActions.GET_INITIAL_USERDATA, requestCredentials),
+    takeLatest(configActions.GET_INITIAL_USERDATA, requestSuggestedPassword),
+    takeLatest(pdataActions.POST_USERDATA, savePersonalData),
+    takeLatest(openidActions.POST_OIDC_PROOFING_PROOFING, requestOpenidQRcode),
+    takeLatest(openidFrejaActions.POST_OIDC_PROOFING_FREJA_PROOFING, sagasOpenidFreja.initializeOpenidFrejaData),
+    takeLatest(openidFrejaActions.GET_OIDC_PROOFING_FREJA_PROOFING, sagasOpenidFreja.requestOpenidFrejaData),
+    takeLatest(openidFrejaActions.SHOW_OIDC_FREJA_MODAL, sagasOpenidFreja.checkNINAndShowFrejaModal),
+    takeLatest(openidFrejaActions.HIDE_OIDC_FREJA_MODAL, sagasOpenidFreja.closeFrejaModal),
+    takeLatest(emailActions.POST_EMAIL, saveEmail),
+    takeLatest(emailActions.START_RESEND_EMAIL_CODE, requestResendEmailCode),
+    takeLatest(emailActions.START_VERIFY, requestVerifyEmail),
+    takeLatest(emailActions.POST_EMAIL_REMOVE, requestRemoveEmail),
+    takeLatest(emailActions.POST_EMAIL_PRIMARY, requestMakePrimaryEmail),
+    takeLatest(mobileActions.POST_MOBILE, sagasMobile.saveMobile),
+    takeLatest(mobileActions.POST_MOBILE_REMOVE, sagasMobile.requestRemoveMobile),
+    takeLatest(mobileActions.POST_MOBILE_PRIMARY, sagasMobile.requestMakePrimaryMobile),
+    takeLatest(mobileActions.START_RESEND_MOBILE_CODE, sagasMobile.requestResendMobileCode),
+    takeLatest(mobileActions.START_VERIFY, sagasMobile.requestVerifyMobile),
+    takeLatest(securityActions.GET_CHANGE_PASSWORD, requestPasswordChange),
+    takeLatest(pwActions.POST_PASSWORD_CHANGE, postPasswordChange),
+    takeLatest(securityActions.POST_DELETE_ACCOUNT, postDeleteAccount),
+    takeLatest(letterActions.POST_LETTER_PROOFING_CODE, sendLetterProofing),
+    takeLatest(letterActions.POST_LETTER_PROOFING_PROOFING, sendLetterCode),
+    takeLatest(ninActions.POST_NIN_REMOVE, requestRemoveNin),
+    takeEvery(letterActions.STOP_LETTER_PROOFING, requestNins),
+    takeEvery(ninActions.POST_NIN_REMOVE_SUCCESS, requestNins),
+    takeEvery(letterActions.POST_LETTER_PROOFING_CODE_SUCCESS, requestNins),
+    takeEvery(headerActions.POST_LOGOUT, requestLogout),
+  ];
+}
+
+export default rootSaga;


### PR DESCRIPTION
There was a regression where it was attempted to fetch the initial user data before the initail config settings had been fetched. It  was introduced in an attempt to avoid fetching useless user data in the case we are only rendering the FREJA component. With this fix, the regression is fixed, and fetching useless data is avioided.

There is also a bit of refactoring, moving some of the code in init-app.js to its own module.