### PR TITLE
remove spinner when cancelling password change

### DIFF
--- a/react/src/components/ChangePassword.js
+++ b/react/src/components/ChangePassword.js
@@ -144,7 +144,7 @@ class ChpassForm extends Component {
                             {this.props.l10n('chpass.change-password')}
                   </EduIDButton>
                   <Button className="cancel-button eduid-cancel-button"
-                        onClick={() => this.props.history.push(this.props.cancel_to)} >
+                        onClick={this.props.handleStopPasswordChange.bind(this)} >
                      {this.props.l10n('cm.cancel')}
                   </Button>
               </fieldset>

--- a/react/src/containers/ChangePassword.js
+++ b/react/src/containers/ChangePassword.js
@@ -6,6 +6,7 @@ import i18n from 'i18n-messages';
 import ChangePassword from 'components/ChangePassword';
 import * as comp from 'components/ChangePassword';
 import * as actions from 'actions/ChangePassword';
+import { stopConfirmationPassword } from 'actions/Security';
 
 
 
@@ -74,6 +75,15 @@ const mapDispatchToProps = (dispatch, props) => {
             }
             dispatch(actions.postPasswordChange(oldPassword, newPassword));
         },
+
+        handleStopPasswordChange: function (event) {
+            event.preventDefault();
+            this.props.history.push(this.props.cancel_to)
+            dispatch(stopConfirmationPassword());
+        },
+
+
+
         loadZxcvbn: function () {
             return new Promise(resolve => {
                 require.ensure([], () => {  

--- a/react/src/reducers/Security.js
+++ b/react/src/reducers/Security.js
@@ -45,6 +45,7 @@ let securityReducer = (state=security, action) => {
     case actions.STOP_CHANGE_PASSWORD:
       return {
         ...state,
+        is_fetching: false,
         confirming_change: false
       };
     case actions.GET_CHANGE_PASSWORD:


### PR DESCRIPTION
Fix a problem that, when changing password and cancelling it, the "change password" button in the security tab would remain spinning and disabled