### PR TITLE
Styling PR | Fixes broken styling in Firefox, Safari and Edge

### DIFF
--- a/static/css/login.css
+++ b/static/css/login.css
@@ -324,6 +324,25 @@ ul.nav.navbar-nav li a:hover {
   margin: 44px auto 0;
 }
 
+.col-md-offset-3,
+.col-md-6,
+.col-md-1,
+.col-md-2,
+.col-md-3,
+.col-md-4,
+.col-md-5,
+.col-md-6,
+.col-md-7,
+.col-md-8,
+.col-md-9,
+.col-md-10,
+.col-md-11,
+.col-md-12 {
+  margin-left: 0;
+  width: 100%;
+  float: none;
+}
+
 @media (max-width: 823px) {
   .row::after,
   .container::after {

--- a/static/css/login.css
+++ b/static/css/login.css
@@ -1,7 +1,7 @@
 ﻿/* header */
 header {
   width: calc(100% - 5px);
-  margin-bottom: 295px; 
+  margin-bottom: 295px;
   display: flex;
   background-color: white;
 }
@@ -90,6 +90,7 @@ form .well,
 
 fieldset {
   display: flex;
+  flex-direction: column;
   flex: 1;
 }
 

--- a/static/css/login.css
+++ b/static/css/login.css
@@ -4,6 +4,7 @@ header {
   margin-bottom: 295px;
   display: flex;
   background-color: white;
+  z-index: 10;
 }
 
 ul {
@@ -18,6 +19,11 @@ legend,
 .navbar-header,
 .navbar-brand {
   display: none;
+}
+
+.well {
+  background-color: transparent;
+  border: none;
 }
 
 .col-md-12,

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -299,6 +299,25 @@ button.btn.btn-default:disabled {
   margin: 44px auto 0;
 }
 
+.col-md-offset-3,
+.col-md-6,
+.col-md-1,
+.col-md-2,
+.col-md-3,
+.col-md-4,
+.col-md-5,
+.col-md-6,
+.col-md-7,
+.col-md-8,
+.col-md-9,
+.col-md-10,
+.col-md-11,
+.col-md-12 {
+  margin-left: 0;
+  width: 100%;
+  float: none;
+}
+
 /* reset password breakpoints */
 
 @media (max-width: 823px) {

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -61,7 +61,7 @@ p {
 .row form {
   width: 58.3333333333%;
   margin: 0 auto;
-  background-color: #f4f4f4;
+  /* background-color: #f4f4f4; */
   box-shadow: none;
   border: none;
 }


### PR DESCRIPTION
Background: Styling of the login form is broken in Safari and Firefox (as per screenshots).

Summary: 
- I have fixed the flexing of the `<fieldset>` surrounding the `<form>` so that the inputs stack
- I have removed the gray background colour from the `<form>` element holding the inputs
- I have overridden some legacy bootstrap styles that fixes broken styling in Edge 

![Screenshot 2019-10-02 at 15 34 46](https://user-images.githubusercontent.com/30963614/66048722-53deac80-e52a-11e9-834b-48aa04adc6a7.png)

![Screenshot 2019-10-02 at 15 34 19](https://user-images.githubusercontent.com/30963614/66048727-580aca00-e52a-11e9-9578-57d94b81e832.png)
