### PR TITLE
Fixes the behaviour of the footer links  

### DIFF
--- a/static/css/login.css
+++ b/static/css/login.css
@@ -92,6 +92,8 @@ form .well,
 #content {
   flex: 1;
   border-bottom: solid #ff4500 8px;
+  background-color: #f4f4f4;
+  z-index: 100;
 }
 
 fieldset {
@@ -295,7 +297,6 @@ ul.nav.navbar-nav li a:hover {
   top: 0;
   right: 0;
   left: 0;
-  z-index: -10;
 }
 
 .container::after {


### PR DESCRIPTION
Background: Due to consisting of html bent into position with css, the footer links appear above the footer line when window height is compressed (as per screenshot). 

<img width="494" alt="Screenshot 2019-10-04 at 14 01 03" src="https://user-images.githubusercontent.com/30963614/66206307-01c79380-e6b0-11e9-8e06-4806e0f1ba71.png">

Summary: 
- I have added a gray background color to the section above the footer line (#content) 
- I have increased the z-index (100) of the same section so the footer links can hide behind
- To minimise future z-index confusion I was also able to remove a redundant negative z-index

Checked in: Chrome, Firefox and Safari



