### PR TITLE
Fixes broken styling on Reset Password page

### DIFF
--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -386,7 +386,10 @@ button.btn.btn-default:disabled {
     width: 75%;
   }
   .row p,
-  .row form {
+  .row form,
+  .nav-tabs,
+  .form,
+  .tab-content {
     padding: 0;
     width: 75%;
   }
@@ -414,7 +417,10 @@ button.btn.btn-default:disabled {
     width: calc(100% - 40px);
   }
   .row p,
-  .row form {
+  .row form,
+  .nav-tabs,
+  .form,
+  .tab-content {
     padding: 0;
     width: calc(100% - 40px);
   }

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -327,7 +327,6 @@ button.btn.btn-default:disabled {
   border: none;
 }
 
-.nav,
 .nav-tabs,
 .form,
 .tab-content {
@@ -344,7 +343,7 @@ button.btn.btn-default:disabled {
   border: none;
 }
 
-.nav li {
+.nav-tabs li {
   height: 48px;
   transition: all 0.5s ease;
   cursor: pointer;

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -129,7 +129,8 @@ form {
 
 .form-group {
   margin-bottom: 0;
-  height: 100px;
+  /* height: 100px; */
+  height: 100%;
 }
 
 .form-control {
@@ -313,6 +314,68 @@ button.btn.btn-default:disabled {
   color: transparent;
   height: 0;
   width: 0;
+}
+
+/*reset password styling */
+
+.tab-content.well {
+  display: flex;
+  margin: 0;
+  flex-direction: column;
+  min-height: 100%;
+  padding: 0;
+  border: none;
+}
+
+.nav,
+.nav-tabs,
+.form,
+.tab-content {
+  border: none;
+  width: 58%;
+  margin: 0 auto;
+}
+
+.nav {
+  margin-top: 36px;
+}
+
+.nav ul {
+  border: none;
+}
+
+.nav li {
+  height: 48px;
+  transition: all 0.5s ease;
+  cursor: pointer;
+}
+
+.nav li a {
+  font-family: "Akkurat";
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: 0.5px;
+  color: #161616;
+}
+
+.nav-tabs > li.active > a,
+.nav-tabs > li.active > a:hover,
+.nav-tabs > li.active > a:focus {
+  color: #ff4500;
+  background-color: white;
+  cursor: pointer;
+  border: none;
+  border-bottom-color: transparent;
+}
+
+.form-group,
+.tab-content > .active {
+  display: contents;
+}
+
+.form-group p {
+  margin: 0 16px 16px 16px;
+  width: 100%;
 }
 
 /* reset password breakpoints */


### PR DESCRIPTION
**Background**: The styling of **Reset password > Choose password** is broken (see screenshot). 

<img width="600" alt="Screenshot 2019-10-29 at 14 32 30" src="https://user-images.githubusercontent.com/30963614/68465820-7ba0ee80-0213-11ea-89a3-8a1ea249a469.png">

> Template complicates styling. I have aimed to give users a more helpful structure. 

Summary: 
- I have changes the structure of page and highlighted elements in a way that is a bit more helpful
- Mobile styling added as far a possible 
- The stylesheet is shared with Login page, so Login should look the same 