### PR TITLE
Mobile fix: Fixes broken footer at bottom of page in Safari

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -40,7 +40,7 @@
 }
 
 body {
-  height: 100vh;
+  min-height: 100vh;
   font-family: "ProximaNova-Regular", Arial, Helvetica, sans-serif;
   font-size: 16px;
   line-height: 1.5;


### PR DESCRIPTION
#### Description:
Fixes broken footer at bottom of html pages (as described in [issue 223](https://github.com/SUNET/eduid-front/issues/223))

- This is only an issue in Safari and therefore also iOS
- This is only an issue in the pages rendered with html: Home and FAQ 

Summary: 
- `height: 100vh` only works in Chrome and Firefox
- `min-height: 100vh` works in Chrome, Firefox and Safari

<img width="500" alt="Screenshot 2020-03-12 at 16 36 39" src="https://user-images.githubusercontent.com/30963614/76538526-bd6ec980-647f-11ea-9e2e-0a0344618744.png">


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

