### PR TITLE
Fixes text overlap on login screen

### DIFF
--- a/static/css/login.css
+++ b/static/css/login.css
@@ -317,7 +317,7 @@ ul.nav.navbar-nav li a:hover {
   line-height: 1.2;
   /* font-weight: 700; */
   position: absolute;
-  top: 285px;
+  top: 38%;
   left: 20.888%;
   width: 58.3333333333%;
   /* margin: 44px auto 0; */

--- a/static/css/login.css
+++ b/static/css/login.css
@@ -304,7 +304,6 @@ ul.nav.navbar-nav li a:hover {
   font-size: 36px;
   font-weight: 700;
   line-height: 1.2;
-  /* padding: 112px 0 103px; */
   width: calc(58.3333333333% + 36px);
   margin: 0 auto;
 }
@@ -312,21 +311,17 @@ ul.nav.navbar-nav li a:hover {
 .row::after {
   content: "Log in to setup or edit your eduID.";
   display: block;
-  /* color: #161616; */
   font-size: 24px;
   line-height: 1.2;
-  /* font-weight: 700; */
   position: absolute;
   top: 38%;
   left: 20.888%;
   width: 58.3333333333%;
-  /* margin: 44px auto 0; */
 }
 
 .footer::after {
   content: "© SUNET 2013-2019";
   display: block;
-  /* color: #161616; */
   font-size: 16px;
   line-height: 1.2;
   font-weight: 400;


### PR DESCRIPTION
#### Description: Text overlaps with input label on iPad and iPad mini due to shorter than expected window height on actual devices (described in eduid-front issue [#263](https://github.com/SUNET/eduid-front/issues/263)). 

*Browser based review of devices on desktop in Safari should not be taken at face value. These need to be manually shortened to account for the browser itself, URL input and browser tabs as these reduce the total height of the window.*

**Summary:**
-  The text line in question only exists in css and had a position set based on the top of the window
     - The distance from top was changed form `px` to `%`
     - This distorts the spacing but stops the elements form overlapping 
- The real fix for this is to release the login app in React

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

