### PR TITLE
Fixes for rendering in safari (at smallest screen)

### DIFF
--- a/static/css/login.css
+++ b/static/css/login.css
@@ -57,7 +57,7 @@ form .well,
   box-shadow: 0 5px 17px rgba(89, 89, 89, 0.07);
   transition: all 0.5s ease;
   cursor: pointer;
-  margin: 16px 16px 0 0;
+  margin: 10px 0 0 0;
 }
 
 .button.orange a,
@@ -70,9 +70,9 @@ form .well,
 .navbar-nav.navbar-right:last-child,
 .navbar-right {
   float: none !important;
-  margin: 0;
-  display: flex;
-  align-items: center;
+  margin-right: 10px;
+  /* display: flex;
+  align-items: center; */
 }
 
 /* structure */
@@ -243,7 +243,6 @@ button.btn.btn-primary:disabled {
 .footer p {
   display: none;
 }
-
 
 /* header nav moved to footer */
 #eduid-idp-menu a,

--- a/static/css/login.css
+++ b/static/css/login.css
@@ -71,8 +71,6 @@ form .well,
 .navbar-right {
   float: none !important;
   margin-right: 10px;
-  /* display: flex;
-  align-items: center; */
 }
 
 /* structure */
@@ -306,17 +304,6 @@ ul.nav.navbar-nav li a:hover {
   width: calc(58.3333333333% + 36px);
   margin: 0 auto;
 }
-
-/* .row::after {
-  content: "Log in to setup or edit your eduID.";
-  display: block;
-  font-size: 24px;
-  line-height: 1.2;
-  position: absolute;
-  top: 38%;
-  left: 20.888%;
-  width: 58.3333333333%;
-} */
 
 .footer::after {
   content: "© SUNET 2013-2019";

--- a/static/css/login.css
+++ b/static/css/login.css
@@ -308,7 +308,7 @@ ul.nav.navbar-nav li a:hover {
   margin: 0 auto;
 }
 
-.row::after {
+/* .row::after {
   content: "Log in to setup or edit your eduID.";
   display: block;
   font-size: 24px;
@@ -317,7 +317,7 @@ ul.nav.navbar-nav li a:hover {
   top: 38%;
   left: 20.888%;
   width: 58.3333333333%;
-}
+} */
 
 .footer::after {
   content: "© SUNET 2013-2019";

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -9,7 +9,6 @@ html {
   overflow-x: hidden;
   display: flex;
   flex-direction: column;
-  /* background-color: yellow; */
 }
 
 body {
@@ -19,7 +18,6 @@ body {
   font-size: 16px !important;
   color: #161616;
   background-color: #f4f4f4;
-  /* background-color: hotpink; */
   display: flex;
   flex: 1;
 }
@@ -39,7 +37,6 @@ p {
 
 /* Structure */
 .container {
-  /* background-color: yellow; */
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -120,7 +117,6 @@ input:focus {
 
 /* valid form input*/
 form {
-  /* background-color: lightblue; */
   display: flex;
   flex: 1;
   justify-content: space-between;
@@ -249,12 +245,8 @@ button.btn.btn-default:disabled {
   border-color: #d8d8d8;
 }
 
-/* .row h2 {
-  display: none;
-} */
 
 /* new content */
-
 .row h1::before {
   content: " ";
   display: block;
@@ -334,10 +326,6 @@ button.btn.btn-default:disabled {
   width: 58%;
   margin: 0 auto;
 }
-
-/* .nav {
-  margin-top: 36px;
-} */
 
 .nav ul {
   border: none;

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -335,9 +335,9 @@ button.btn.btn-default:disabled {
   margin: 0 auto;
 }
 
-.nav {
+/* .nav {
   margin-top: 36px;
-}
+} */
 
 .nav ul {
   border: none;


### PR DESCRIPTION
#### Description: The complicated styling as the new design was applied to the login page using only css requires some fixes for rendering in Safari (issue [#280](https://github.com/SUNET/eduid-front/issues/280) reported in the eduid-front repo) 

**Fix:** the pseudo-element text added with css (does not exist in the DOM) has been removes as it was very difficult to position for all devices and sizes. Until the new version is ready, we will have to assume that users understand that they are on the login page. 

**Summary:** 
- removed log in prompt text
- fixed the 'Sign up' header button (on small screens but also works on bigger screens) 

--- 
###### Login screen (before and after): 
<img width="300" alt="Screenshot 2020-05-06 at 13 40 25" src="https://user-images.githubusercontent.com/30963614/81174825-c7560a00-8fa2-11ea-9216-30452764e5e6.png"> <img width="300" alt="Screenshot 2020-05-06 at 13 58 58" src="https://user-images.githubusercontent.com/30963614/81174829-c9b86400-8fa2-11ea-839d-a143c07e9d45.png">



#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

