### PR TITLE
HELP: Language link on left side, all other pages on right side

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -202,7 +202,7 @@ footer {
   border-top: solid #ff4500 8px;
   display: flex;
   align-items: baseline;
-  justify-content: space-between;
+  justify-content: flex-end;
   padding: 16px;
   font-size: 16px;
 }


### PR DESCRIPTION
#### Description:
Issue https://github.com/SUNET/eduid-front/issues/302

#### Summary:
Adjust `justify-content:flex-end` to have same position as other pages

----
- Before/After
<img width="1435" alt="Screenshot 2020-09-24 at 09 21 23" src="https://user-images.githubusercontent.com/44289056/94113536-56c36300-fe47-11ea-98a1-4366f24b1b0f.png">

<img width="1440" alt="Screenshot 2020-09-24 at 09 18 43" src="https://user-images.githubusercontent.com/44289056/94113312-ffbd8e00-fe46-11ea-8830-80d9449c4b64.png">

----

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

