### PR TITLE
copyright positioning fix

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -212,6 +212,7 @@ footer a {
   font-size: 1rem;
   line-height: 1;
   padding-top: 0;
+  flex: 1;
 }
 
 footer nav,


### PR DESCRIPTION
#### Description:
[Issue 522](https://github.com/SUNET/eduid-front/issues/522)

- Start page (Before)

<img width="300" alt="Screenshot 2021-02-01 at 15 34 48" src="https://user-images.githubusercontent.com/44289056/106472551-12a23800-64a3-11eb-8a1d-c6593a3bb4e3.png">

- Start page (After)
<img width="300" alt="Screenshot 2021-02-01 at 15 32 51" src="https://user-images.githubusercontent.com/44289056/106472310-d40c7d80-64a2-11eb-8bdd-7bff08a0aa48.png">






#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

