### PR TITLE
Revert vertical-spacing refactor - to match app

### DIFF
--- a/en/faq.html
+++ b/en/faq.html
@@ -22,7 +22,7 @@
     </section>
 
     <section class="panel">
-      <div class="horizontal-content-margin">
+      <div class="horizontal-content-margin content">
         <ul class="faq">
           <li>
             <h4>What is eduID?</h4>

--- a/en/index.html
+++ b/en/index.html
@@ -23,7 +23,7 @@
     </section>
 
     <section class="panel">
-      <div class="horizontal-content-margin">
+      <div class="horizontal-content-margin content">
         <p class="intro">
           Create an eduID and connect it to your Swedish national identity number to gain access to services and
           organisations related to higher education.

--- a/faq.html
+++ b/faq.html
@@ -22,7 +22,7 @@
     </section>
 
     <section class="panel">
-      <div class="horizontal-content-margin">
+      <div class="horizontal-content-margin content">
         <ul class="faq">
           <li>
             <h4>Vad är eduID?</h4>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     </section>
 
     <section class="panel">
-      <div class="horizontal-content-margin">
+      <div class="horizontal-content-margin content">
         <p class="intro">
           Skapa ett eduID och koppla det till ditt svenska personnummer för att kunna komma åt flera olika tjänster och
           organisationer inom högskolan.

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -71,12 +71,14 @@ body {
 }
 
 .panel {
-  padding: 3rem 0 6rem;
+  padding-bottom: 6rem;
   display: flex;
   flex: 1;
   background-color: #f4f4f4;
 }
-
+.panel .content {
+  padding-top: 3rem;
+}
 .horizontal-content-margin {
   padding: 0;
   width: 58%;
@@ -253,7 +255,10 @@ footer .text-link {
     margin: 1rem 0 1.5rem;
   }
   .panel {
-    padding: 2rem 0 4rem;
+    padding-bottom: 4rem;
+  }
+  .panel .content {
+    padding-top: 2rem;
   }
 }
 


### PR DESCRIPTION
#### Description:
Vertical content was simplified in app (all applied to panel), but top padding need to be applied inside, due to notification bar, thus reverted in app and here - to maintain framework identical.

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

